### PR TITLE
remove std::ascii::AsciiExt import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::ascii::AsciiExt;
 use std::str::FromStr;
 
 use self::RenameRule::*;


### PR DESCRIPTION
Functionality previously behind this import is now inherent, and it is now
deprecated.

(No idea why vim added a newline at the bottom.)